### PR TITLE
Bugfix TcpdumpLog function: makes sure folder is created before log file is written + debug prints added

### DIFF
--- a/example/controlScenario.json
+++ b/example/controlScenario.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "controlScenario",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
-
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
     "event":[
         {
             "beginTime" : 1,

--- a/example/controlScenario.yaml
+++ b/example/controlScenario.yaml
@@ -1,6 +1,8 @@
 scenarioName: controlScenario
-logPath: "/home/colin/Documents/colin/log"
-topo: "/home/colin/Documents/colin/topo/bgp_features/topo.yaml"
+logPath: "/home/samy/samy_internship/emulation/log"
+topo: "/home/samy/samy_internship/emulation/bgp_features/topo.yaml"
+data: "/home/samy/samy_internship/emulation/bgp_features/data.json"
+
 event:
 - beginTime: 1
   type: pumba

--- a/example/corrupt_all_devices_25.json
+++ b/example/corrupt_all_devices_25.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "corrupt_all_devices_25",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
-
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
     "event":[
         {
             "beginTime" : 1,

--- a/example/corrupt_duplicate_r2_r1.json
+++ b/example/corrupt_duplicate_r2_r1.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "corrupt_duplicate_r2_r1",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
-
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
     "event":[
         {
             "beginTime" : 2,

--- a/example/corrupt_r2_25.json
+++ b/example/corrupt_r2_25.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "corrupt_r2_25",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/corrupt_r2_r1_25.json
+++ b/example/corrupt_r2_r1_25.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "corrupt_r2_r1_25",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/delay_all_devices_300.json
+++ b/example/delay_all_devices_300.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "delay_all_devices_300",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/delay_r2_300.json
+++ b/example/delay_r2_300.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "delay_r2_300",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/delay_r2_r1_25.json
+++ b/example/delay_r2_r1_25.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "delay_r2_r1_25",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
-
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
     "event":[
         {
             "beginTime" : 2,

--- a/example/duplicate_all_devices_25.json
+++ b/example/duplicate_all_devices_25.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "duplicate_all_devices_25",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/duplicate_r2_25.json
+++ b/example/duplicate_r2_25.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "duplicate_r2_25",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/duplicate_r2_r1_25.json
+++ b/example/duplicate_r2_r1_25.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "duplicate_r2_r1_25",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/loss_all_devices_25.json
+++ b/example/loss_all_devices_25.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "loss_all_devices_25",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/loss_r2_25.json
+++ b/example/loss_r2_25.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "loss_r2_25",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/loss_r2_r1_25.json
+++ b/example/loss_r2_r1_25.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "loss_r2_r1_25",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/pause_corrupt_all_devices.json
+++ b/example/pause_corrupt_all_devices.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "pause_corrupt_all_devices",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
-
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
     "event":[
         {
             "beginTime" : 1,

--- a/example/pause_duplicate_all_devices.json
+++ b/example/pause_duplicate_all_devices.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "pause_duplicate_all_devices",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/pause_loss_all_devices.json
+++ b/example/pause_loss_all_devices.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "pause_loss_all_devices",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/pause_r1.json
+++ b/example/pause_r1.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "pause_r1",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/pause_r2.json
+++ b/example/pause_r2.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "pause_r2",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/pause_r3.json
+++ b/example/pause_r3.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "pause_r3",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/pkg/model/read.go
+++ b/pkg/model/read.go
@@ -57,7 +57,7 @@ func ReadYaml() error {
 }
 
 func ReadJsonData() error {
-	file, err := os.Open(FindTopoPath() + "data.json")
+	file, err := os.Open(Scenar.Data)
 	if err != nil {
 		fmt.Println("Fail to open the file")
 		return err

--- a/pkg/model/scenario.go
+++ b/pkg/model/scenario.go
@@ -34,6 +34,7 @@ type Event struct {
 type Scenario struct {
 	ScenarioName string  `json:"scenarioName" yaml:"scenarioName"`
 	Topo         string  `json:"topo" yaml:"topo"`
+	Data         string  `json:"data" yaml:"data"`
 	LogPath      string  `json:"logPath" yaml:"logPath"`
 	Event        []Event `json:"event" yaml:"event"`
 }

--- a/pkg/network/log.go
+++ b/pkg/network/log.go
@@ -196,57 +196,78 @@ func FlushLogFiles(logFiles []string) error {
 }
 
 func TcpdumpLog(index int) error {
-
 	containerNameArray := strings.Split(model.Scenar.Event[0].Host, "-")
 	containerName := strings.Join(containerNameArray[:len(containerNameArray)-1], "-")
+	fmt.Println("Container Name: ", containerName) // Debug print
 
-	file, err := os.Create(model.FindTopoPath() + "/r" + strconv.Itoa(index+1) + "/" + "tcpdump.sh")
+	// Build directory path
+	topoPath := model.FindTopoPath() + "/r" + strconv.Itoa(index+1)
+	scriptPath := topoPath + "/tcpdump.sh"
+
+	// Create directory if necessary
+	err := os.MkdirAll(topoPath, 0755)
 	if err != nil {
-		fmt.Println("Error while creating tcpdump.sh file")
+		fmt.Println("Error while creating directory:", err)
+		return err
+	}
+
+	// Create the tcpdump.sh file
+	file, err := os.Create(scriptPath)
+	if err != nil {
+		fmt.Println("Error while creating tcpdump.sh file:", err)
 		return err
 	}
 	defer file.Close()
 
-	err = os.Chmod(model.FindTopoPath()+"/r"+strconv.Itoa(index+1)+"/"+"tcpdump.sh", 0775)
+	// Change the permissions of the tcpdump.sh file
+	err = os.Chmod(scriptPath, 0775)
 	if err != nil {
-		fmt.Println("Error while changing tcpdump.sh permission")
+		fmt.Println("Error while changing tcpdump.sh permission:", err)
 		return err
 	}
 
+	// Create the tcpdump directory in the container
 	cmd := exec.Command("sudo", "docker", "exec", "-d", containerName+"-r"+strconv.Itoa(index+1), "mkdir", "tcpdump")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		fmt.Println("Error while creating tcpdump directory")
+	var output []byte
+	output, err = cmd.CombinedOutput()
+	if err != nil{
+		fmt.Println("Error while creating tcpdump directory:", err)
 		log.Println(string(output))
 		return err
 	}
 
+	
+
+	// Write the script in tcpdump.sh
 	_, err = file.WriteString("#!/bin/sh \n")
 	if err != nil {
-		fmt.Println("Error while writing in tcpdump.sh file")
+		fmt.Println("Error while writing in tcpdump.sh file:", err)
 		return err
 	}
 
+	// Add tcpdump commands for each interface
 	for _, inter := range model.Devices.Nodes[index].Interfaces {
 		_, err = file.WriteString("tcpdump -i " + inter.Name + " -n -v > tcpdump/tcpdump" + "_" + inter.Name + ".log & \n")
 		if err != nil {
-			fmt.Println("Error while writing in tcpdump.sh file")
+			fmt.Println("Error while writing in tcpdump.sh file:", err)
 			return err
 		}
 	}
 
-	cmd = exec.Command("sudo", "docker", "cp", model.FindTopoPath()+"/r"+strconv.Itoa(index+1)+"/"+"tcpdump.sh", containerName+"-r"+strconv.Itoa(index+1)+":/")
+	// Copy the tcpdump.sh script into the container
+	cmd = exec.Command("sudo", "docker", "cp", scriptPath, containerName+"-r"+strconv.Itoa(index+1)+":/")
 	output, err = cmd.CombinedOutput()
 	if err != nil {
-		fmt.Println("Error while copying tcpdump script in the host container")
+		fmt.Println("Error while copying tcpdump script in the host container:", err)
 		log.Println(string(output))
 		return err
 	}
 
+	// Run the tcpdump.sh script in the container
 	cmd = exec.Command("sudo", "docker", "exec", "-d", containerName+"-r"+strconv.Itoa(index+1), "./tcpdump.sh")
 	output, err = cmd.CombinedOutput()
 	if err != nil {
-		fmt.Println("Error while starting tcpdump")
+		fmt.Println("Error while starting tcpdump:", err)
 		log.Println(string(output))
 		return err
 	}

--- a/pkg/network/log.go
+++ b/pkg/network/log.go
@@ -198,7 +198,7 @@ func FlushLogFiles(logFiles []string) error {
 func TcpdumpLog(index int) error {
 	containerNameArray := strings.Split(model.Scenar.Event[0].Host, "-")
 	containerName := strings.Join(containerNameArray[:len(containerNameArray)-1], "-")
-	fmt.Println("Container Name: ", containerName) // Debug print
+	// fmt.Println("Container Name: ", containerName) // Debug print
 
 	// Build directory path
 	topoPath := model.FindTopoPath() + "/r" + strconv.Itoa(index+1)

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,7 @@ Netroub reproduces network failure behaviors described in a scenario file on Doc
 | scenarioName | string | Name of the scenario (useful for outputs)
 | logPath      | string | Path to the output repository
 | topo         | string | Path to the topology file required by Containerlab
+| data         | string | Path to the data file with device parameter
 | events       | array  | Array of event to be applied during scenario execution
 
 ## Citation


### PR DESCRIPTION
The Tcpdumplog function did not ensure that the folder was created before trying to write the log file to it, which could lead to errors. The modifications made correct this.