### PR TITLE
Bugfix TcpdumpLog function: makes sure folder is created before log file is written + debug prints added

### DIFF
--- a/pkg/network/log.go
+++ b/pkg/network/log.go
@@ -196,57 +196,78 @@ func FlushLogFiles(logFiles []string) error {
 }
 
 func TcpdumpLog(index int) error {
-
 	containerNameArray := strings.Split(model.Scenar.Event[0].Host, "-")
 	containerName := strings.Join(containerNameArray[:len(containerNameArray)-1], "-")
+	// fmt.Println("Container Name: ", containerName) // Debug print
 
-	file, err := os.Create(model.FindTopoPath() + "/r" + strconv.Itoa(index+1) + "/" + "tcpdump.sh")
+	// Build directory path
+	topoPath := model.FindTopoPath() + "/r" + strconv.Itoa(index+1)
+	scriptPath := topoPath + "/tcpdump.sh"
+
+	// Create directory if necessary
+	err := os.MkdirAll(topoPath, 0755)
 	if err != nil {
-		fmt.Println("Error while creating tcpdump.sh file")
+		fmt.Println("Error while creating directory:", err)
+		return err
+	}
+
+	// Create the tcpdump.sh file
+	file, err := os.Create(scriptPath)
+	if err != nil {
+		fmt.Println("Error while creating tcpdump.sh file:", err)
 		return err
 	}
 	defer file.Close()
 
-	err = os.Chmod(model.FindTopoPath()+"/r"+strconv.Itoa(index+1)+"/"+"tcpdump.sh", 0775)
+	// Change the permissions of the tcpdump.sh file
+	err = os.Chmod(scriptPath, 0775)
 	if err != nil {
-		fmt.Println("Error while changing tcpdump.sh permission")
+		fmt.Println("Error while changing tcpdump.sh permission:", err)
 		return err
 	}
 
+	// Create the tcpdump directory in the container
 	cmd := exec.Command("sudo", "docker", "exec", "-d", containerName+"-r"+strconv.Itoa(index+1), "mkdir", "tcpdump")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		fmt.Println("Error while creating tcpdump directory")
+	var output []byte
+	output, err = cmd.CombinedOutput()
+	if err != nil{
+		fmt.Println("Error while creating tcpdump directory:", err)
 		log.Println(string(output))
 		return err
 	}
 
+	
+
+	// Write the script in tcpdump.sh
 	_, err = file.WriteString("#!/bin/sh \n")
 	if err != nil {
-		fmt.Println("Error while writing in tcpdump.sh file")
+		fmt.Println("Error while writing in tcpdump.sh file:", err)
 		return err
 	}
 
+	// Add tcpdump commands for each interface
 	for _, inter := range model.Devices.Nodes[index].Interfaces {
 		_, err = file.WriteString("tcpdump -i " + inter.Name + " -n -v > tcpdump/tcpdump" + "_" + inter.Name + ".log & \n")
 		if err != nil {
-			fmt.Println("Error while writing in tcpdump.sh file")
+			fmt.Println("Error while writing in tcpdump.sh file:", err)
 			return err
 		}
 	}
 
-	cmd = exec.Command("sudo", "docker", "cp", model.FindTopoPath()+"/r"+strconv.Itoa(index+1)+"/"+"tcpdump.sh", containerName+"-r"+strconv.Itoa(index+1)+":/")
+	// Copy the tcpdump.sh script into the container
+	cmd = exec.Command("sudo", "docker", "cp", scriptPath, containerName+"-r"+strconv.Itoa(index+1)+":/")
 	output, err = cmd.CombinedOutput()
 	if err != nil {
-		fmt.Println("Error while copying tcpdump script in the host container")
+		fmt.Println("Error while copying tcpdump script in the host container:", err)
 		log.Println(string(output))
 		return err
 	}
 
+	// Run the tcpdump.sh script in the container
 	cmd = exec.Command("sudo", "docker", "exec", "-d", containerName+"-r"+strconv.Itoa(index+1), "./tcpdump.sh")
 	output, err = cmd.CombinedOutput()
 	if err != nil {
-		fmt.Println("Error while starting tcpdump")
+		fmt.Println("Error while starting tcpdump:", err)
 		log.Println(string(output))
 		return err
 	}


### PR DESCRIPTION
The Tcpdumplog function did not ensure that the folder was created before trying to write the log file to it, which could lead to errors. The modifications made correct this.