### PR TITLE
Fixing DestroyNetwork function

### DIFF
--- a/example/controlScenario.json
+++ b/example/controlScenario.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "controlScenario",
-    "logPath" : "/home/samy/samy_internship/emulation/log",
-    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
-    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
+    "logPath" : "/path/to/log_directory",
+    "topo":"/path/to/topo.yaml",
+    "data": "/path/to/data.json",
     "event":[
         {
             "beginTime" : 1,

--- a/example/controlScenario.json
+++ b/example/controlScenario.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "controlScenario",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
-
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
     "event":[
         {
             "beginTime" : 1,

--- a/example/controlScenario.json
+++ b/example/controlScenario.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "controlScenario",
-    "logPath" : "/path/to/log_directory",
-    "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data.json",
+    "logPath" : "./path_to_log_directory",
+    "topo":"./path_to_topo.yaml",
+    "data": "./path_to_data.json",
     "event":[
         {
             "beginTime" : 1,

--- a/example/controlScenario.yaml
+++ b/example/controlScenario.yaml
@@ -1,7 +1,7 @@
 scenarioName: controlScenario
-logPath: "/path/to/log_directory"
-topo: "/path/to/topo.yaml"
-data: "/path/to/data.json"
+logPath: "./path_to_log_directory"
+topo: "./path_to_topo.yaml"
+data: "./path_to_data.json"
 
 event:
 - beginTime: 1

--- a/example/controlScenario.yaml
+++ b/example/controlScenario.yaml
@@ -1,7 +1,7 @@
 scenarioName: controlScenario
-logPath: "/home/samy/samy_internship/emulation/log"
-topo: "/home/samy/samy_internship/emulation/bgp_features/topo.yaml"
-data: "/home/samy/samy_internship/emulation/bgp_features/data.json"
+logPath: "/path/to/log_directory"
+topo: "/path/to/topo.yaml"
+data: "/path/to/data"
 
 event:
 - beginTime: 1

--- a/example/controlScenario.yaml
+++ b/example/controlScenario.yaml
@@ -1,7 +1,7 @@
 scenarioName: controlScenario
 logPath: "/path/to/log_directory"
 topo: "/path/to/topo.yaml"
-data: "/path/to/data"
+data: "/path/to/data.json"
 
 event:
 - beginTime: 1

--- a/example/controlScenario.yaml
+++ b/example/controlScenario.yaml
@@ -1,6 +1,8 @@
 scenarioName: controlScenario
-logPath: "/home/colin/Documents/colin/log"
-topo: "/home/colin/Documents/colin/topo/bgp_features/topo.yaml"
+logPath: "/home/samy/samy_internship/emulation/log"
+topo: "/home/samy/samy_internship/emulation/bgp_features/topo.yaml"
+data: "/home/samy/samy_internship/emulation/bgp_features/data.json"
+
 event:
 - beginTime: 1
   type: pumba

--- a/example/corrupt_all_devices_25.json
+++ b/example/corrupt_all_devices_25.json
@@ -2,7 +2,7 @@
     "scenarioName" : "corrupt_all_devices_25",
     "logPath" : "/path/to/log_directory",
     "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data",
+    "data": "/path/to/data.json",
     "event":[
         {
             "beginTime" : 1,

--- a/example/corrupt_all_devices_25.json
+++ b/example/corrupt_all_devices_25.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "corrupt_all_devices_25",
-    "logPath" : "/path/to/log_directory",
-    "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data.json",
+    "logPath" : "./path_to_log_directory",
+    "topo":"./path_to_topo.yaml",
+    "data": "./path_to_data.json",
     "event":[
         {
             "beginTime" : 1,

--- a/example/corrupt_all_devices_25.json
+++ b/example/corrupt_all_devices_25.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "corrupt_all_devices_25",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
-
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
     "event":[
         {
             "beginTime" : 1,

--- a/example/corrupt_all_devices_25.json
+++ b/example/corrupt_all_devices_25.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "corrupt_all_devices_25",
-    "logPath" : "/home/samy/samy_internship/emulation/log",
-    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
-    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
+    "logPath" : "/path/to/log_directory",
+    "topo":"/path/to/topo.yaml",
+    "data": "/path/to/data",
     "event":[
         {
             "beginTime" : 1,

--- a/example/corrupt_duplicate_r2_r1.json
+++ b/example/corrupt_duplicate_r2_r1.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "corrupt_duplicate_r2_r1",
-    "logPath" : "/path/to/log_directory",
-    "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data.json",
+    "logPath" : "./path_to_log_directory",
+    "topo":"./path_to_topo.yaml",
+    "data": "./path_to_data.json",
     "event":[
         {
             "beginTime" : 2,

--- a/example/corrupt_duplicate_r2_r1.json
+++ b/example/corrupt_duplicate_r2_r1.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "corrupt_duplicate_r2_r1",
-    "logPath" : "/home/samy/samy_internship/emulation/log",
-    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
-    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
+    "logPath" : "/path/to/log_directory",
+    "topo":"/path/to/topo.yaml",
+    "data": "/path/to/data",
     "event":[
         {
             "beginTime" : 2,

--- a/example/corrupt_duplicate_r2_r1.json
+++ b/example/corrupt_duplicate_r2_r1.json
@@ -2,7 +2,7 @@
     "scenarioName" : "corrupt_duplicate_r2_r1",
     "logPath" : "/path/to/log_directory",
     "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data",
+    "data": "/path/to/data.json",
     "event":[
         {
             "beginTime" : 2,

--- a/example/corrupt_duplicate_r2_r1.json
+++ b/example/corrupt_duplicate_r2_r1.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "corrupt_duplicate_r2_r1",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
-
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
     "event":[
         {
             "beginTime" : 2,

--- a/example/corrupt_r2_25.json
+++ b/example/corrupt_r2_25.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "corrupt_r2_25",
-    "logPath" : "/path/to/log_directory",
-    "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data.json",
+    "logPath" : "./path_to_log_directory",
+    "topo":"./path_to_topo.yaml",
+    "data": "./path_to_data.json",
 
     "event":[
         {

--- a/example/corrupt_r2_25.json
+++ b/example/corrupt_r2_25.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "corrupt_r2_25",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/corrupt_r2_25.json
+++ b/example/corrupt_r2_25.json
@@ -2,7 +2,7 @@
     "scenarioName" : "corrupt_r2_25",
     "logPath" : "/path/to/log_directory",
     "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data",
+    "data": "/path/to/data.json",
 
     "event":[
         {

--- a/example/corrupt_r2_25.json
+++ b/example/corrupt_r2_25.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "corrupt_r2_25",
-    "logPath" : "/home/samy/samy_internship/emulation/log",
-    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
-    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
+    "logPath" : "/path/to/log_directory",
+    "topo":"/path/to/topo.yaml",
+    "data": "/path/to/data",
 
     "event":[
         {

--- a/example/corrupt_r2_r1_25.json
+++ b/example/corrupt_r2_r1_25.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "corrupt_r2_r1_25",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/corrupt_r2_r1_25.json
+++ b/example/corrupt_r2_r1_25.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "corrupt_r2_r1_25",
-    "logPath" : "/path/to/log_directory",
-    "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data.json",
+    "logPath" : "./path_to_log_directory",
+    "topo":"./path_to_topo.yaml",
+    "data": "./path_to_data.json",
 
     "event":[
         {

--- a/example/corrupt_r2_r1_25.json
+++ b/example/corrupt_r2_r1_25.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "corrupt_r2_r1_25",
-    "logPath" : "/home/samy/samy_internship/emulation/log",
-    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
-    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
+    "logPath" : "/path/to/log_directory",
+    "topo":"/path/to/topo.yaml",
+    "data": "/path/to/data",
 
     "event":[
         {

--- a/example/corrupt_r2_r1_25.json
+++ b/example/corrupt_r2_r1_25.json
@@ -2,7 +2,7 @@
     "scenarioName" : "corrupt_r2_r1_25",
     "logPath" : "/path/to/log_directory",
     "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data",
+    "data": "/path/to/data.json",
 
     "event":[
         {

--- a/example/delay_all_devices_300.json
+++ b/example/delay_all_devices_300.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "delay_all_devices_300",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/delay_all_devices_300.json
+++ b/example/delay_all_devices_300.json
@@ -2,7 +2,7 @@
     "scenarioName" : "delay_all_devices_300",
     "logPath" : "/path/to/log_directory",
     "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data",
+    "data": "/path/to/data.json",
 
     "event":[
         {

--- a/example/delay_all_devices_300.json
+++ b/example/delay_all_devices_300.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "delay_all_devices_300",
-    "logPath" : "/home/samy/samy_internship/emulation/log",
-    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
-    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
+    "logPath" : "/path/to/log_directory",
+    "topo":"/path/to/topo.yaml",
+    "data": "/path/to/data",
 
     "event":[
         {

--- a/example/delay_all_devices_300.json
+++ b/example/delay_all_devices_300.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "delay_all_devices_300",
-    "logPath" : "/path/to/log_directory",
-    "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data.json",
+    "logPath" : "./path_to_log_directory",
+    "topo":"./path_to_topo.yaml",
+    "data": "./path_to_data.json",
 
     "event":[
         {

--- a/example/delay_r2_300.json
+++ b/example/delay_r2_300.json
@@ -2,7 +2,7 @@
     "scenarioName" : "delay_r2_300",
     "logPath" : "/path/to/log_directory",
     "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data",
+    "data": "/path/to/data.json",
 
     "event":[
         {

--- a/example/delay_r2_300.json
+++ b/example/delay_r2_300.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "delay_r2_300",
-    "logPath" : "/path/to/log_directory",
-    "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data.json",
+    "logPath" : "./path_to_log_directory",
+    "topo":"./path_to_topo.yaml",
+    "data": "./path_to_data.json",
 
     "event":[
         {

--- a/example/delay_r2_300.json
+++ b/example/delay_r2_300.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "delay_r2_300",
-    "logPath" : "/home/samy/samy_internship/emulation/log",
-    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
-    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
+    "logPath" : "/path/to/log_directory",
+    "topo":"/path/to/topo.yaml",
+    "data": "/path/to/data",
 
     "event":[
         {

--- a/example/delay_r2_300.json
+++ b/example/delay_r2_300.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "delay_r2_300",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/delay_r2_r1_25.json
+++ b/example/delay_r2_r1_25.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "delay_r2_r1_25",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
-
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
     "event":[
         {
             "beginTime" : 2,

--- a/example/delay_r2_r1_25.json
+++ b/example/delay_r2_r1_25.json
@@ -2,7 +2,7 @@
     "scenarioName" : "delay_r2_r1_25",
     "logPath" : "/path/to/log_directory",
     "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data",
+    "data": "/path/to/data.json",
     "event":[
         {
             "beginTime" : 2,

--- a/example/delay_r2_r1_25.json
+++ b/example/delay_r2_r1_25.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "delay_r2_r1_25",
-    "logPath" : "/home/samy/samy_internship/emulation/log",
-    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
-    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
+    "logPath" : "/path/to/log_directory",
+    "topo":"/path/to/topo.yaml",
+    "data": "/path/to/data",
     "event":[
         {
             "beginTime" : 2,

--- a/example/delay_r2_r1_25.json
+++ b/example/delay_r2_r1_25.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "delay_r2_r1_25",
-    "logPath" : "/path/to/log_directory",
-    "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data.json",
+    "logPath" : "./path_to_log_directory",
+    "topo":"./path_to_topo.yaml",
+    "data": "./path_to_data.json",
     "event":[
         {
             "beginTime" : 2,

--- a/example/duplicate_all_devices_25.json
+++ b/example/duplicate_all_devices_25.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "duplicate_all_devices_25",
-    "logPath" : "/home/samy/samy_internship/emulation/log",
-    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
-    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
+    "logPath" : "/path/to/log_directory",
+    "topo":"/path/to/topo.yaml",
+    "data": "/path/to/data",
 
     "event":[
         {

--- a/example/duplicate_all_devices_25.json
+++ b/example/duplicate_all_devices_25.json
@@ -2,7 +2,7 @@
     "scenarioName" : "duplicate_all_devices_25",
     "logPath" : "/path/to/log_directory",
     "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data",
+    "data": "/path/to/data.json",
 
     "event":[
         {

--- a/example/duplicate_all_devices_25.json
+++ b/example/duplicate_all_devices_25.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "duplicate_all_devices_25",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/duplicate_all_devices_25.json
+++ b/example/duplicate_all_devices_25.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "duplicate_all_devices_25",
-    "logPath" : "/path/to/log_directory",
-    "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data.json",
+    "logPath" : "./path_to_log_directory",
+    "topo":"./path_to_topo.yaml",
+    "data": "./path_to_data.json",
 
     "event":[
         {

--- a/example/duplicate_r2_25.json
+++ b/example/duplicate_r2_25.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "duplicate_r2_25",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/duplicate_r2_25.json
+++ b/example/duplicate_r2_25.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "duplicate_r2_25",
-    "logPath" : "/path/to/log_directory",
-    "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data.json",
+    "logPath" : "./path_to_log_directory",
+    "topo":"./path_to_topo.yaml",
+    "data": "./path_to_data.json",
 
     "event":[
         {

--- a/example/duplicate_r2_25.json
+++ b/example/duplicate_r2_25.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "duplicate_r2_25",
-    "logPath" : "/home/samy/samy_internship/emulation/log",
-    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
-    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
+    "logPath" : "/path/to/log_directory",
+    "topo":"/path/to/topo.yaml",
+    "data": "/path/to/data.json",
 
     "event":[
         {

--- a/example/duplicate_r2_r1_25.json
+++ b/example/duplicate_r2_r1_25.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "duplicate_r2_r1_25",
-    "logPath" : "/path/to/log_directory",
-    "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data.json",
+    "logPath" : "./path_to_log_directory",
+    "topo":"./path_to_topo.yaml",
+    "data": "./path_to_data.json",
 
     "event":[
         {

--- a/example/duplicate_r2_r1_25.json
+++ b/example/duplicate_r2_r1_25.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "duplicate_r2_r1_25",
-    "logPath" : "/home/samy/samy_internship/emulation/log",
-    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
-    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
+    "logPath" : "/path/to/log_directory",
+    "topo":"/path/to/topo.yaml",
+    "data": "/path/to/data.json",
 
     "event":[
         {

--- a/example/duplicate_r2_r1_25.json
+++ b/example/duplicate_r2_r1_25.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "duplicate_r2_r1_25",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/loss_all_devices_25.json
+++ b/example/loss_all_devices_25.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "loss_all_devices_25",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/loss_all_devices_25.json
+++ b/example/loss_all_devices_25.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "loss_all_devices_25",
-    "logPath" : "/home/samy/samy_internship/emulation/log",
-    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
-    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
+    "logPath" : "/path/to/log_directory",
+    "topo":"/path/to/topo.yaml",
+    "data": "/path/to/data.json",
 
     "event":[
         {

--- a/example/loss_all_devices_25.json
+++ b/example/loss_all_devices_25.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "loss_all_devices_25",
-    "logPath" : "/path/to/log_directory",
-    "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data.json",
+    "logPath" : "./path_to_log_directory",
+    "topo":"./path_to_topo.yaml",
+    "data": "./path_to_data.json",
 
     "event":[
         {

--- a/example/loss_r2_25.json
+++ b/example/loss_r2_25.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "loss_r2_25",
-    "logPath" : "/path/to/log_directory",
-    "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data.json",
+    "logPath" : "./path_to_log_directory",
+    "topo":"./path_to_topo.yaml",
+    "data": "./path_to_data.json",
 
     "event":[
         {

--- a/example/loss_r2_25.json
+++ b/example/loss_r2_25.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "loss_r2_25",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/loss_r2_25.json
+++ b/example/loss_r2_25.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "loss_r2_25",
-    "logPath" : "/home/samy/samy_internship/emulation/log",
-    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
-    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
+    "logPath" : "/path/to/log_directory",
+    "topo":"/path/to/topo.yaml",
+    "data": "/path/to/data.json",
 
     "event":[
         {

--- a/example/loss_r2_r1_25.json
+++ b/example/loss_r2_r1_25.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "loss_r2_r1_25",
-    "logPath" : "/home/samy/samy_internship/emulation/log",
-    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
-    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
+    "logPath" : "/path/to/log_directory",
+    "topo":"/path/to/topo.yaml",
+    "data": "/path/to/data.json",
 
     "event":[
         {

--- a/example/loss_r2_r1_25.json
+++ b/example/loss_r2_r1_25.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "loss_r2_r1_25",
-    "logPath" : "/path/to/log_directory",
-    "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data.json",
+    "logPath" : "./path_to_log_directory",
+    "topo":"./path_to_topo.yaml",
+    "data": "./path_to_data.json",
 
     "event":[
         {

--- a/example/loss_r2_r1_25.json
+++ b/example/loss_r2_r1_25.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "loss_r2_r1_25",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/pause_corrupt_all_devices.json
+++ b/example/pause_corrupt_all_devices.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "pause_corrupt_all_devices",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
-
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
     "event":[
         {
             "beginTime" : 1,

--- a/example/pause_corrupt_all_devices.json
+++ b/example/pause_corrupt_all_devices.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "pause_corrupt_all_devices",
-    "logPath" : "/home/samy/samy_internship/emulation/log",
-    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
-    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
+    "logPath" : "/path/to/log_directory",
+    "topo":"/path/to/topo.yaml",
+    "data": "/path/to/data.json",
     "event":[
         {
             "beginTime" : 1,

--- a/example/pause_corrupt_all_devices.json
+++ b/example/pause_corrupt_all_devices.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "pause_corrupt_all_devices",
-    "logPath" : "/path/to/log_directory",
-    "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data.json",
+    "logPath" : "./path_to_log_directory",
+    "topo":"./path_to_topo.yaml",
+    "data": "./path_to_data.json",
     "event":[
         {
             "beginTime" : 1,

--- a/example/pause_corrupt_all_devices.json
+++ b/example/pause_corrupt_all_devices.json
@@ -3,6 +3,7 @@
     "logPath" : "./path_to_log_directory",
     "topo":"./path_to_topo.yaml",
     "data": "./path_to_data.json",
+    
     "event":[
         {
             "beginTime" : 1,

--- a/example/pause_duplicate_all_devices.json
+++ b/example/pause_duplicate_all_devices.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "pause_duplicate_all_devices",
-    "logPath" : "/home/samy/samy_internship/emulation/log",
-    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
-    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
+    "logPath" : "/path/to/log_directory",
+    "topo":"/path/to/topo.yaml",
+    "data": "/path/to/data.json",
 
     "event":[
         {

--- a/example/pause_duplicate_all_devices.json
+++ b/example/pause_duplicate_all_devices.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "pause_duplicate_all_devices",
-    "logPath" : "/path/to/log_directory",
-    "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data.json",
+    "logPath" : "./path_to_log_directory",
+    "topo":"./path_to_topo.yaml",
+    "data": "./path_to_data.json",
 
     "event":[
         {

--- a/example/pause_duplicate_all_devices.json
+++ b/example/pause_duplicate_all_devices.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "pause_duplicate_all_devices",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/pause_loss_all_devices.json
+++ b/example/pause_loss_all_devices.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "pause_loss_all_devices",
-    "logPath" : "/home/samy/samy_internship/emulation/log",
-    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
-    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
+    "logPath" : "/path/to/log_directory",
+    "topo":"/path/to/topo.yaml",
+    "data": "/path/to/data.json",
 
     "event":[
         {

--- a/example/pause_loss_all_devices.json
+++ b/example/pause_loss_all_devices.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "pause_loss_all_devices",
-    "logPath" : "/path/to/log_directory",
-    "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data.json",
+    "logPath" : "./path_to_log_directory",
+    "topo":"./path_to_topo.yaml",
+    "data": "./path_to_data.json",
 
     "event":[
         {

--- a/example/pause_loss_all_devices.json
+++ b/example/pause_loss_all_devices.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "pause_loss_all_devices",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/pause_r1.json
+++ b/example/pause_r1.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "pause_r1",
-    "logPath" : "/home/samy/samy_internship/emulation/log",
-    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
-    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
+    "logPath" : "/path/to/log_directory",
+    "topo":"/path/to/topo.yaml",
+    "data": "/path/to/data.json",
 
     "event":[
         {

--- a/example/pause_r1.json
+++ b/example/pause_r1.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "pause_r1",
-    "logPath" : "/path/to/log_directory",
-    "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data.json",
+    "logPath" : "./path_to_log_directory",
+    "topo":"./path_to_topo.yaml",
+    "data": "./path_to_data.json",
 
     "event":[
         {

--- a/example/pause_r1.json
+++ b/example/pause_r1.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "pause_r1",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/pause_r2.json
+++ b/example/pause_r2.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "pause_r2",
-    "logPath" : "/path/to/log_directory",
-    "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data.json",
+    "logPath" : "./path_to_log_directory",
+    "topo":"./path_to_topo.yaml",
+    "data": "./path_to_data.json",
 
     "event":[
         {

--- a/example/pause_r2.json
+++ b/example/pause_r2.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "pause_r2",
-    "logPath" : "/home/samy/samy_internship/emulation/log",
-    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
-    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
+    "logPath" : "/path/to/log_directory",
+    "topo":"/path/to/topo.yaml",
+    "data": "/path/to/data.json",
 
     "event":[
         {

--- a/example/pause_r2.json
+++ b/example/pause_r2.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "pause_r2",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/pause_r3.json
+++ b/example/pause_r3.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "pause_r3",
-    "logPath" : "/home/samy/samy_internship/emulation/log",
-    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
-    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
+    "logPath" : "/path/to/log_directory",
+    "topo":"/path/to/topo.yaml",
+    "data": "/path/to/data.json",
 
     "event":[
         {

--- a/example/pause_r3.json
+++ b/example/pause_r3.json
@@ -1,7 +1,8 @@
 {
     "scenarioName" : "pause_r3",
-    "logPath" : "/home/colin/Documents/colin/log",
-    "topo":"/home/colin/Documents/colin/topo/bgp_features/topo.yaml",
+    "logPath" : "/home/samy/samy_internship/emulation/log",
+    "topo":"/home/samy/samy_internship/emulation/bgp_features/topo.yaml",
+    "data": "/home/samy/samy_internship/emulation/bgp_features/data.json",
 
     "event":[
         {

--- a/example/pause_r3.json
+++ b/example/pause_r3.json
@@ -1,8 +1,8 @@
 {
     "scenarioName" : "pause_r3",
-    "logPath" : "/path/to/log_directory",
-    "topo":"/path/to/topo.yaml",
-    "data": "/path/to/data.json",
+    "logPath" : "./path_to_log_directory",
+    "topo":"./path_to_topo.yaml",
+    "data": "./path_to_data.json",
 
     "event":[
         {

--- a/pkg/model/read.go
+++ b/pkg/model/read.go
@@ -57,7 +57,7 @@ func ReadYaml() error {
 }
 
 func ReadJsonData() error {
-	file, err := os.Open(FindTopoPath() + "data.json")
+	file, err := os.Open(Scenar.Data)
 	if err != nil {
 		fmt.Println("Fail to open the file")
 		return err

--- a/pkg/model/scenario.go
+++ b/pkg/model/scenario.go
@@ -34,6 +34,7 @@ type Event struct {
 type Scenario struct {
 	ScenarioName string  `json:"scenarioName" yaml:"scenarioName"`
 	Topo         string  `json:"topo" yaml:"topo"`
+	Data         string  `json:"data" yaml:"data"`
 	LogPath      string  `json:"logPath" yaml:"logPath"`
 	Event        []Event `json:"event" yaml:"event"`
 }

--- a/pkg/network/emulation.go
+++ b/pkg/network/emulation.go
@@ -53,23 +53,25 @@ func DestroyNetwork() error {
 		return err
 	}
 
-	cmd := exec.Command("sudo", "rm", "-rf", path+"/"+topoName)
+	
+
+	cmd := exec.Command("sudo", "containerlab", "destroy", "--topo", model.Scenar.Topo)
 	out, err := cmd.Output()
+	if err != nil {
+		fmt.Println("Error while destroy the emulated network")
+		return err
+	}
+	fmt.Println(string(out))
+
+	cmd = exec.Command("sudo", "rm", "-rf", path+"/"+topoName)
+	out, err = cmd.Output()
 	if err != nil {
 		fmt.Println("Error while suppressing file")
 		return err
 	}
 	fmt.Println(string(out))
 
-	cmd = exec.Command("sudo", "containerlab", "destroy", "--topo", model.Scenar.Topo)
-	out, err = cmd.Output()
-	if err != nil {
-		fmt.Println("Errore while destroy the emulated network")
-		return err
-	}
-	fmt.Println(string(out))
 	return nil
-
 }
 
 func CreateDockerClient(c *cli.Context) error {

--- a/pkg/network/emulation.go
+++ b/pkg/network/emulation.go
@@ -53,21 +53,22 @@ func DestroyNetwork() error {
 		return err
 	}
 
-	cmd := exec.Command("sudo", "rm", "-rf", path+"/"+topoName)
+	cmd := exec.Command("sudo", "containerlab", "destroy", "--topo", model.Scenar.Topo)
 	out, err := cmd.Output()
+	if err != nil {
+		fmt.Println("Error while destroy the emulated network")
+		return err
+	}
+	fmt.Println(string(out))
+
+	cmd = exec.Command("sudo", "rm", "-rf", path+"/"+topoName)
+	out, err = cmd.Output()
 	if err != nil {
 		fmt.Println("Error while suppressing file")
 		return err
 	}
 	fmt.Println(string(out))
 
-	cmd = exec.Command("sudo", "containerlab", "destroy", "--topo", model.Scenar.Topo)
-	out, err = cmd.Output()
-	if err != nil {
-		fmt.Println("Errore while destroy the emulated network")
-		return err
-	}
-	fmt.Println(string(out))
 	return nil
 
 }

--- a/pkg/network/emulation.go
+++ b/pkg/network/emulation.go
@@ -53,22 +53,21 @@ func DestroyNetwork() error {
 		return err
 	}
 
-	cmd := exec.Command("sudo", "containerlab", "destroy", "--topo", model.Scenar.Topo)
+	cmd := exec.Command("sudo", "rm", "-rf", path+"/"+topoName)
 	out, err := cmd.Output()
-	if err != nil {
-		fmt.Println("Error while destroy the emulated network")
-		return err
-	}
-	fmt.Println(string(out))
-
-	cmd = exec.Command("sudo", "rm", "-rf", path+"/"+topoName)
-	out, err = cmd.Output()
 	if err != nil {
 		fmt.Println("Error while suppressing file")
 		return err
 	}
 	fmt.Println(string(out))
 
+	cmd = exec.Command("sudo", "containerlab", "destroy", "--topo", model.Scenar.Topo)
+	out, err = cmd.Output()
+	if err != nil {
+		fmt.Println("Errore while destroy the emulated network")
+		return err
+	}
+	fmt.Println(string(out))
 	return nil
 
 }

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,7 @@ Netroub reproduces network failure behaviors described in a scenario file on Doc
 | scenarioName | string | Name of the scenario (useful for outputs)
 | logPath      | string | Path to the output repository
 | topo         | string | Path to the topology file required by Containerlab
+| data         | string | Path to the data file with device parameters
 | events       | array  | Array of event to be applied during scenario execution
 
 ## Citation


### PR DESCRIPTION
A code error in the DestroyNetwork function: it first deleted the emulation files and then asked containerlab to delete the emulated network, causing a systematic error because the files were not found by containerlab. It was then necessary to manually delete all the docker images one by one before restarting netroub. Corrected, netroub now destroys the emulated network with the associated docker images at the end of each simulation.